### PR TITLE
Move Convert Into A Class (fixes #12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ python:
   - "3.5"
   - "3.6-dev"
   - "3.6"
-  - "nightly"
 script: nosetests

--- a/README.rst
+++ b/README.rst
@@ -51,11 +51,14 @@ Conversions between Python and OpenMath
 =======================================
 
 This package provides facilities for easy conversions from Python to
-OpenMath and back. The module ``convert`` contains two functions,
-``to_python()`` and ``to_openmath()``, that do the conversion as their
-names suggest, or raise a ``ValueError`` if no conversion is known.
+OpenMath and back. The module ``convert`` contains a ``Converter`` class, which
+is used to implements this functionality. For convenienve, an instance of this
+class, ``DefaultConverter`` is provided.
 
-This module only implements conversions for basic Python types:
+The two functions ``to_python()`` and ``to_openmath()`` do the conversion as
+their  names suggest, or raise a ``ValueError`` if no conversion is known.
+
+By default, a ``Converter`` only implements conversions for basic Python types:
 
 - bools,
 - ints,
@@ -69,23 +72,24 @@ This module only implements conversions for basic Python types:
 Furthermore, any object that defines an ``__openmath__(self)`` method
 will have that method called by ``to_python``.
 
-Finally, this module contains a mechanism for registering converters.
+Finally, this class contains a mechanism for registering converters.
 
 ::
 
    >>> from fractions import Fraction
-   >>> from openmath import convert, openmath as om
+   >>> from openmath import openmath as om
+   >>> from openmath.convert import DefaultConverter as converter
    >>> def to_om_rat(obj):
    ...     return om.OMApplication(om.OMSymbol('rational', cd='nums1'),
-   ...                             list(map(convert.to_openmath, [obj.numerator, obj.denominator])))
+   ...                             list(map(converter.to_openmath, [obj.numerator, obj.denominator])))
    ...
    >>> def to_py_rat(obj):
-   ...     return Fraction(convert.to_python(obj.arguments[0]), convert.to_python(obj.arguments[1]))
+   ...     return Fraction(converter.to_python(obj.arguments[0]), converter.to_python(obj.arguments[1]))
    ...
-   >>> convert.register(Fraction, to_om_rat, 'nums1', 'rational', to_py_rat)
-   >>> omobj = convert.to_openmath(Fraction(5, 6)); omobj
+   >>> converter.register(Fraction, to_om_rat, 'nums1', 'rational', to_py_rat)
+   >>> omobj = converter.to_openmath(Fraction(5, 6)); omobj
    OMApplication(OMSymbol('rational', 'nums1', id=None, cdbase=None), [OMInteger(5, id=None), OMInteger(6, id=None)], id=None, cdbase=None)
-   >>> convert.to_python(omobj)
+   >>> converter.to_python(omobj)
    Fraction(5, 6)
 
 

--- a/openmath/convert.py
+++ b/openmath/convert.py
@@ -2,11 +2,15 @@
 Mapping of native Python types to OpenMath
 
 This modules implements conversions from Python objects to OpenMath and
-back. The two main functions are ``to_python()`` and ``to_openmath()``,
+back. All state is encapsulated in a class called ``Converter``. For
+convenience, a default instance ``DefaultConverter`` is provided.
+
+The two main functions are ``to_python()`` and ``to_openmath()``,
 which do the conversion as the name suggests, or raise a ``ValueError``
 if no conversion is known.
 
-This module only implements conversions for basic Python types:
+By default, a Converter class only implements conversions for basic Python
+types:
 
 - bools,
 - ints,
@@ -20,7 +24,7 @@ This module only implements conversions for basic Python types:
 Furthermore, any object that defines an ``__openmath__(self)`` method
 will get that method called by ``to_python``.
 
-Finally, this module contains a mechanism for registering converters.
+Finally, the class contains a mechanism for registering converters.
 
 The function ``register_to_python()`` takes either two or three inputs.
 The form ``register_to_python(om_class, conv)`` expects a subclass of
@@ -58,181 +62,189 @@ import six
 from inspect import isclass
 from . import openmath as om
 
-# A list of converters from python types to OM
-_conv_to_om = []
+class Converter(object):
+    """
+    A class implementing conversion between native Python and OpenMath objects
+    """
+    def __init__(self):
+        # A list of converters from python types to OM
+        self._conv_to_om = []
 
-# A dictionary to override OM basic tags
-_conv_to_py = {}
-# A dictionary to convert OM symbols
-_conv_sym_to_py = {
-    ('nums1', 'infinity'):             float('inf'),
-    ('logic1', 'true'):                True,
-    ('logic1', 'false'):               False,
-    ('list1', 'list'):                 lambda obj: [to_python(x) for x in obj.arguments],
-    ('set1', 'emptyset'):              set(),
-    ('set1', 'set'):                   lambda obj: set(to_python(x) for x in obj.arguments),
-    ('complex1', 'complex_cartesian'): lambda obj: complex(obj.arguments[0].double,
-                                                               obj.arguments[1].double),
-}
+        # A dictionary to override OM basic tags
+        self._conv_to_py = {}
+        # A dictionary to convert OM symbols
+        self._conv_sym_to_py = {
+            ('nums1', 'infinity'):             float('inf'),
+            ('logic1', 'true'):                True,
+            ('logic1', 'false'):               False,
+            ('list1', 'list'):                 lambda obj: [self.to_python(x) for x in obj.arguments],
+            ('set1', 'emptyset'):              set(),
+            ('set1', 'set'):                   lambda obj: set(self.to_python(x) for x in obj.arguments),
+            ('complex1', 'complex_cartesian'): lambda obj: complex(obj.arguments[0].double, obj.arguments[1].double),
+        }
+    
+    def to_python(self, omobj):
+        """ Convert OpenMath object to Python """
+        if omobj.__class__ in self._conv_to_py:
+            return self._conv_to_py[omobj.__class__](omobj)
+        elif isinstance(omobj, om.OMInteger):
+            return omobj.integer
+        elif isinstance(omobj, om.OMFloat):
+            return omobj.double
+        elif isinstance(omobj, om.OMString):
+            return omobj.string
+        elif isinstance(omobj, om.OMBytes):
+            return omobj.bytes
+        elif isinstance(omobj, om.OMSymbol):
+            val = self._conv_sym_to_py.get((omobj.cd, omobj.name))
+            if val is not None:
+                if callable(val):
+                    return val(omobj)
+                else:
+                    return val
+        elif isinstance(omobj, om.OMApplication) and isinstance(omobj.elem, om.OMSymbol):
+            val = self._conv_sym_to_py.get((omobj.elem.cd, omobj.elem.name))
+            if val is not None:
+                if callable(val):
+                    return val(omobj)
+                else:
+                    return val
+
+        raise ValueError('Cannot convert object of class %s to Python.' % omobj.__class__.__name__)
+    
+    def to_openmath(self, obj):
+        """ Convert Python object to OpenMath """
+        for cl, conv in reversed(self._conv_to_om):
+            if cl is None or isinstance(obj, cl):
+                try:
+                    if callable(conv):
+                        return conv(obj)
+                    else:
+                        return conv
+                except CannotConvertError:
+                    continue
+
+        if hasattr(obj, '__openmath__'):
+            return obj.__openmath__()
+
+        if isinstance(obj, bool):
+            return om.OMSymbol(str(obj).lower(), cd='logic1')
+        elif isinstance(obj, six.integer_types):
+            return om.OMInteger(obj)
+        elif isinstance(obj, float):
+            if obj == float('inf'):
+                return om.OMSymbol('infinity', cd='nums1')
+            else:
+                return om.OMFloat(obj)
+        elif isinstance(obj, complex):
+            return om.OMApplication(om.OMSymbol('complex_cartesian', cd='complex1'),
+                                  map(self.to_openmath, [obj.real, obj.imag]))
+        elif isinstance(obj, str):
+            return om.OMString(obj)
+        elif isinstance(obj, bytes):
+            return om.OMBytes(obj)
+        elif isinstance(obj, list):
+            return om.OMApplication(om.OMSymbol('list', cd='list1'), map(self.to_openmath, obj))
+        elif isinstance(obj, set):
+            if obj:
+                return om.OMApplication(om.OMSymbol('set', cd='set1'), map(self.to_openmath, obj))
+            else:
+                return om.OMSymbol('emptyset', cd='set1')
+
+        raise ValueError('Cannot convert %r to OpenMath.' % obj)
+
+    def register_to_openmath(self, py_class, converter):
+        """Register a converter from Python to OpenMath
+
+        :param py_class: A Python class the converter is attached to, or None
+        :type py_class: None, type
+
+        :param converter: A conversion function or an OpenMath object
+        :type converter: Callable, OMAny
+
+        :rtype: None
+
+        ``converter`` will used to convert any object of type ``py_class``,
+        or any object if ``py_class`` is ``None``. If ``converter`` is an
+        OpenMath object, it is returned immediately. If it is a callable, it
+        is called with the Python object as paramter; in this case, it must
+        either return an OpenMath object, or raise an exception.  The
+        special exception ``CannotConvertError`` can be used to signify that
+        ``converter`` does not know how to convert the current object, and that
+        ``to_openmath`` shall continue with the other converters. Any other
+        exception stops conversion immediately.
+
+        Converters registered by this function are called in order from the
+        most recent to the oldest.
+        """
+        if py_class is not None and not isclass(py_class):
+            raise TypeError('Expected class, found %r' % py_class)
+        if not callable(converter) and not isinstance(converter, om.OMAny):
+            raise TypeError('Expected callable or openmath.OMAny object, found %r' % converter)
+        self._conv_to_om.append((py_class, converter))
+
+    def register_to_python(self, cd, name, converter=None):
+        """Register a converter from OpenMath to Python
+
+        This function has two forms. A three-arguments one:
+
+        :param cd: A content dictionary name
+        :type cd: str
+
+        :param name: A symbol name
+        :type name: str
+
+        :param converter: A conversion function, or a Python object
+        :type: Callable, Any
+
+        Any object of type ``openmath.OMSymbol``, with content
+        dictionary equal to ``cd`` and name equal to ``name`` will be converted
+        using ``converter``. Also, any object of type ``openmath.OMApplication``
+        whose first child is an ``openmath.OMSymbol`` as above will be converted
+        using ``converter``. If ``converter`` is a callable, it will be called with the
+        OpenMath object as parameter; otherwise ``converter`` will be returned.
+
+        In the two-argument form
+
+        :param cd: A subclass of ``OMAny``
+        :type cd: type
+
+        :param name: A conversion function
+        :type name: Callable
+
+        Any object of type ``cd`` will be passed to ``name()``, and the
+        result will be returned. This forms is mainly to override default
+        conversions for basic OpenMath tags (OMInteger, OMString, etc.). It
+        is discouraged to use it for ``OMSymbol`` and ``OMApplication``.
+        """
+        if converter is None:
+            if isclass(cd) and issubclass(cd, om.OMAny):
+                self._conv_to_py[cd] = name
+            else:
+                raise TypeError('Two-arguments form expects subclass of openmath.OMAny, found %r' % cd)
+        else:
+            if isinstance(cd, str) and isinstance(name, str):
+                self._conv_sym_to_py[(cd, name)] = converter
+            else:
+                raise TypeError('Three-arguments form expects string, found %r' % cd.__class__)
+
+    def register(self, py_class, to_om, om_cd, om_name, to_py=None):
+        """
+        Shorthand for
+
+        >>> self.register_to_python(om_cd, om_name, to_py)
+        >>> self.register_to_openmath(py_class, to_om)
+        """
+        self.register_to_python(om_cd, om_name, to_py)
+        self.register_to_openmath(py_class, to_om)
+
+
+# A default converter instance for convenience
+DefaultConverter = Converter()
 
 class CannotConvertError(RuntimeError):
     """
-    Raise this exception if your converter to OpenMath is not able 
+    Raise this exception if your converter to OpenMath is not able
     to handle the inputs.
     """
     pass
-    
-def to_python(omobj):
-    """ Convert OpenMath object to Python """
-    if omobj.__class__ in _conv_to_py:
-        return _conv_to_py[omobj.__class__](omobj)
-    elif isinstance(omobj, om.OMInteger):
-        return omobj.integer
-    elif isinstance(omobj, om.OMFloat):
-        return omobj.double
-    elif isinstance(omobj, om.OMString):
-        return omobj.string
-    elif isinstance(omobj, om.OMBytes):
-        return omobj.bytes
-    elif isinstance(omobj, om.OMSymbol):
-        val = _conv_sym_to_py.get((omobj.cd, omobj.name))
-        if val is not None:
-            if callable(val):
-                return val(omobj)
-            else:
-                return val
-    elif isinstance(omobj, om.OMApplication) and isinstance(omobj.elem, om.OMSymbol):
-        val = _conv_sym_to_py.get((omobj.elem.cd, omobj.elem.name))
-        if val is not None:
-            if callable(val):
-                return val(omobj)
-            else:
-                return val
-
-    raise ValueError('Cannot convert object of class %s to Python.' % omobj.__class__.__name__)
-    
-def to_openmath(obj):
-    """ Convert Python object to OpenMath """
-    for cl, conv in reversed(_conv_to_om):
-        if cl is None or isinstance(obj, cl):
-            try:
-                if callable(conv):
-                    return conv(obj)
-                else:
-                    return conv
-            except CannotConvertError:
-                continue
-    
-    if hasattr(obj, '__openmath__'):
-        return obj.__openmath__()
-
-    if isinstance(obj, bool):
-        return om.OMSymbol(str(obj).lower(), cd='logic1')
-    elif isinstance(obj, six.integer_types):
-        return om.OMInteger(obj)
-    elif isinstance(obj, float):
-        if obj == float('inf'):
-            return om.OMSymbol('infinity', cd='nums1')
-        else:
-            return om.OMFloat(obj)
-    elif isinstance(obj, complex):
-        return om.OMApplication(om.OMSymbol('complex_cartesian', cd='complex1'),
-                              map(to_openmath, [obj.real, obj.imag]))
-    elif isinstance(obj, str):
-        return om.OMString(obj)
-    elif isinstance(obj, bytes):
-        return om.OMBytes(obj)
-    elif isinstance(obj, list):
-        return om.OMApplication(om.OMSymbol('list', cd='list1'), map(to_openmath, obj))
-    elif isinstance(obj, set):
-        if obj:
-            return om.OMApplication(om.OMSymbol('set', cd='set1'), map(to_openmath, obj))
-        else:
-            return om.OMSymbol('emptyset', cd='set1')
-
-    raise ValueError('Cannot convert %r to OpenMath.' % obj)
-
-def register_to_openmath(py_class, converter):
-    """Register a converter from Python to OpenMath
-
-    :param py_class: A Python class the converter is attached to, or None
-    :type py_class: None, type
-    
-    :param converter: A conversion function or an OpenMath object
-    :type converter: Callable, OMAny
-    
-    :rtype: None
-
-    ``converter`` will used to convert any object of type ``py_class``,
-    or any object if ``py_class`` is ``None``. If ``converter`` is an
-    OpenMath object, it is returned immediately. If it is a callable, it
-    is called with the Python object as paramter; in this case, it must
-    either return an OpenMath object, or raise an exception.  The
-    special exception ``CannotConvertError`` can be used to signify that
-    ``converter`` does not know how to convert the current object, and that
-    ``to_openmath`` shall continue with the other converters. Any other
-    exception stops conversion immediately.
-
-    Converters registered by this function are called in order from the
-    most recent to the oldest.
-    """
-    if py_class is not None and not isclass(py_class):
-        raise TypeError('Expected class, found %r' % py_class)
-    if not callable(converter) and not isinstance(converter, om.OMAny):
-        raise TypeError('Expected callable or openmath.OMAny object, found %r' % converter)
-    _conv_to_om.append((py_class, converter))
-
-def register_to_python(cd, name, converter=None):
-    """Register a converter from OpenMath to Python
-
-    This function has two forms. A three-arguments one:
-
-    :param cd: A content dictionary name
-    :type cd: str
-
-    :param name: A symbol name
-    :type name: str
-
-    :param converter: A conversion function, or a Python object
-    :type: Callable, Any
-
-    Any object of type ``openmath.OMSymbol``, with content
-    dictionary equal to ``cd`` and name equal to ``name`` will be converted
-    using ``converter``. Also, any object of type ``openmath.OMApplication``
-    whose first child is an ``openmath.OMSymbol`` as above will be converted
-    using ``converter``. If ``converter`` is a callable, it will be called with the
-    OpenMath object as parameter; otherwise ``converter`` will be returned.
-
-    In the two-argument form 
-
-    :param cd: A subclass of ``OMAny``
-    :type cd: type
-
-    :param name: A conversion function
-    :type name: Callable
-    
-    Any object of type ``cd`` will be passed to ``name()``, and the
-    result will be returned. This forms is mainly to override default
-    conversions for basic OpenMath tags (OMInteger, OMString, etc.). It
-    is discouraged to use it for ``OMSymbol`` and ``OMApplication``.
-    """
-    if converter is None:
-        if isclass(cd) and issubclass(cd, om.OMAny):
-            _conv_to_py[cd] = name
-        else:
-            raise TypeError('Two-arguments form expects subclass of openmath.OMAny, found %r' % cd)
-    else:
-        if isinstance(cd, str) and isinstance(name, str):
-            _conv_sym_to_py[(cd, name)] = converter
-        else:
-            raise TypeError('Three-arguments form expects string, found %r' % om_class)
-
-def register(py_class, to_om, om_cd, om_name, to_py=None):
-    """
-    Shorthand for 
-
-    >>> register_to_python(om_cd, om_name, to_py)
-    >>> register_to_openmath(py_class, to_om)
-    """
-    register_to_python(om_cd, om_name, to_py)
-    register_to_openmath(py_class, to_om)

--- a/openmath/convert.py
+++ b/openmath/convert.py
@@ -1,15 +1,15 @@
 """
 Mapping of native Python types to OpenMath
 
-This modules implements conversions from Python objects to OpenMath and
-back. All state is encapsulated in a class called ``Converter``. For
-convenience, a default instance ``DefaultConverter`` is provided.
+This module implements conversions from Python objects to OpenMath and
+back. All state is encapsulated in instances of the class ``Converter``.
+For convenience, a default instance ``DefaultConverter`` is provided.
 
-The two main functions are ``to_python()`` and ``to_openmath()``,
+The two main methods are ``to_python()`` and ``to_openmath()``,
 which do the conversion as the name suggests, or raise a ``ValueError``
 if no conversion is known.
 
-By default, a Converter class only implements conversions for basic Python
+By default, a converter ``c`` only implements conversions for basic Python
 types:
 
 - bools,
@@ -24,15 +24,15 @@ types:
 Furthermore, any object that defines an ``__openmath__(self)`` method
 will get that method called by ``to_python``.
 
-Finally, the class contains a mechanism for registering converters.
+Finally, the class contains a mechanism for registering additional conversions.
 
-The function ``register_to_python()`` takes either two or three inputs.
-The form ``register_to_python(om_class, conv)`` expects a subclass of
+The method ``c.register_to_python`` takes either two or three inputs.
+The form ``c.register_to_python(om_class, conv)`` expects a subclass of
 ``openmath.OMAny`` as first parameter, and a function as second
 parameter. Any object of type ``om_class`` will be passed to ``conv()``,
 and the result will be returned.
 
-The form ``register_to_python(cd, name, conv)`` expects two strings for
+The form ``c.register_to_python(cd, name, conv)`` expects two strings for
 the arguments ``cd`` and ``name``, and any object for the third
 argument. Any object of type ``openmath.OMSymbol``, with content
 dictionary equal to ``cd`` and name equal to ``name`` will be converted
@@ -41,7 +41,7 @@ whose first child is an ``openmath.OMSymbol`` as above will be converted
 using ``conv``. If ``conv`` is a function, it will be called with the
 OpenMath object as parameter; otherwise ``conv`` will be returned.
 
-The function ``register_to_openmath(py_class, conv)`` takes two
+The method ``c.register_to_openmath(py_class, conv)`` takes two
 parameters, the first being None, or a Python class, the second being a
 function or an OpenMath object. ``conv`` is used to convert any object
 of type ``py_class``, or any object if ``py_class`` is ``None``. If
@@ -80,10 +80,10 @@ from . import openmath as om
 
 class Converter(object):
     """
-    A class implementing conversion between native Python and OpenMath objects
+    A class implementing conversions between native Python and OpenMath objects
     """
     def __init__(self):
-        # A list of converters from python types to OM
+        # A list of conversions from python types to OM
         self._conv_to_om = []
 
         # A dictionary to override OM basic tags
@@ -170,9 +170,9 @@ class Converter(object):
         raise ValueError('Cannot convert %r to OpenMath.' % obj)
 
     def register_to_openmath(self, py_class, converter):
-        """Register a converter from Python to OpenMath
+        """Register a conversion from Python to OpenMath
 
-        :param py_class: A Python class the converter is attached to, or None
+        :param py_class: A Python class the conversion is attached to, or None
         :type py_class: None, type
 
         :param converter: A conversion function or an OpenMath object
@@ -200,7 +200,7 @@ class Converter(object):
         self._conv_to_om.append((py_class, converter))
 
     def register_to_python(self, cd, name, converter=None):
-        """Register a converter from OpenMath to Python
+        """Register a conversion from OpenMath to Python
 
         This function has two forms. A three-arguments one:
 

--- a/openmath/convert.py
+++ b/openmath/convert.py
@@ -54,8 +54,24 @@ special exception ``CannotConvertError`` can be used to signify that
 exception stops conversion immediately.  Converters registered this way
 are called in order from the most recent to the oldest.
 
-Finally, the function ``register()`` may be used as a shortcut for the
-two previous functions.
+Finally, the method ``c.register()`` may be used as a shortcut for the
+two previous methods.
+
+Examples::
+
+    >>> from openmath.convert import DefaultConverter
+    >>> o = DefaultConverter.to_openmath(1); o
+    OMInteger(integer=1, id=None)
+    >>> DefaultConverter.to_python(o)
+    1
+
+For backward compatibility, one may use the following shorthands:
+
+    >>> from openmath.convert import to_openmath, to_python, register_to_openmath, register_to_python
+    >>> o = to_openmath(1); o
+    OMInteger(integer=1, id=None)
+    >>> to_python(o)
+    1
 """
 
 import six
@@ -241,6 +257,11 @@ class Converter(object):
 
 # A default converter instance for convenience
 DefaultConverter = Converter()
+# Shorthands for bacwkard compatibility (and convenience?)
+to_python = DefaultConverter.to_python
+to_openmath = DefaultConverter.to_openmath
+register_to_openmath = DefaultConverter.register_to_openmath
+register_to_python = DefaultConverter.register_to_python
 
 class CannotConvertError(RuntimeError):
     """

--- a/openmath/convert.py
+++ b/openmath/convert.py
@@ -257,9 +257,10 @@ class Converter(object):
 
 # A default converter instance for convenience
 DefaultConverter = Converter()
-# Shorthands for bacwkard compatibility (and convenience?)
+# Shorthands for backward compatibility (and convenience?)
 to_python = DefaultConverter.to_python
 to_openmath = DefaultConverter.to_openmath
+register = DefaultConverter.register
 register_to_openmath = DefaultConverter.register_to_openmath
 register_to_python = DefaultConverter.register_to_python
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -17,48 +17,48 @@ class TestConvert(unittest.TestCase):
             set(), set([1,2,3]),
         ]
         for obj in testcases:
-            conv = DefaultConverter.to_python(DefaultConverter.to_openmath(obj))
+            conv = to_python(to_openmath(obj))
             self.assertEqual(type(obj), type(conv), "Converting %s" % obj.__class__.__name__)
             self.assertEqual(obj, conv, "Converting %s" % obj.__class__.__name__)
-            self.assertRaises(ValueError, DefaultConverter.to_openmath, {})
+            self.assertRaises(ValueError, to_openmath, {})
 
     def test_register_str(self):
         def str_to_om(str):
             return om.OMString('Hello' + str)
         def str_to_py(om):
             return om.string + 'world'
-
-        DefaultConverter.register(str, str_to_om, om.OMString, str_to_py)
-        self.assertEqual(DefaultConverter.to_python(DefaultConverter.to_openmath(' ')), 'Hello world')
+        
+        register(str, str_to_om, om.OMString, str_to_py)
+        self.assertEqual(to_python(to_openmath(' ')), 'Hello world')
 
     def test_register_sym(self):
-        DefaultConverter.register_to_python('hello1', 'hello', 'world')
-        self.assertEqual(DefaultConverter.to_python(om.OMSymbol(cd='hello1', name='hello')), 'world')
+        register_to_python('hello1', 'hello', 'world')
+        self.assertEqual(to_python(om.OMSymbol(cd='hello1', name='hello')), 'world')
         def echo(obj):
             return obj.name
-        DefaultConverter.register_to_python('echo1', 'echo', echo)
-        self.assertEqual(DefaultConverter.to_python(om.OMSymbol(cd='echo1', name='echo')), 'echo')
+        register_to_python('echo1', 'echo', echo)
+        self.assertEqual(to_python(om.OMSymbol(cd='echo1', name='echo')), 'echo')
 
     def test_register_skip(self):
         def skip(obj):
             raise CannotConvertError()
-        DefaultConverter.register_to_openmath(None, skip)
-        self.assertEqual(DefaultConverter.to_openmath('hello'), om.OMString('hello'))
+        register_to_openmath(None, skip)
+        self.assertEqual(to_openmath('hello'), om.OMString('hello'))
 
     def test_underscore(self):
         class test:
             def __openmath__(self):
                 return om.OMInteger(1)
-        self.assertEqual(DefaultConverter.to_python(DefaultConverter.to_openmath(test())), 1)
+        self.assertEqual(to_python(to_openmath(test())), 1)
 
     def test_rational(self):
         def to_om_rat(obj):
             return om.OMApplication(om.OMSymbol('rational', cd='nums1'),
-                                    map(DefaultConverter.to_openmath, [obj.numerator, obj.denominator]))
+                                    map(to_openmath, [obj.numerator, obj.denominator]))
         def to_py_rat(obj):
-            return Fraction(DefaultConverter.to_python(obj.arguments[0]), DefaultConverter.to_python(obj.arguments[1]))
-        DefaultConverter.register(Fraction, to_om_rat, 'nums1', 'rational', to_py_rat)
+            return Fraction(to_python(obj.arguments[0]), to_python(obj.arguments[1]))
+        register(Fraction, to_om_rat, 'nums1', 'rational', to_py_rat)
 
         a = Fraction(10, 12)
-        self.assertEqual(a, DefaultConverter.to_python(DefaultConverter.to_openmath(a)))
+        self.assertEqual(a, to_python(to_openmath(a)))
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -17,48 +17,48 @@ class TestConvert(unittest.TestCase):
             set(), set([1,2,3]),
         ]
         for obj in testcases:
-            conv = to_python(to_openmath(obj))
+            conv = DefaultConverter.to_python(DefaultConverter.to_openmath(obj))
             self.assertEqual(type(obj), type(conv), "Converting %s" % obj.__class__.__name__)
             self.assertEqual(obj, conv, "Converting %s" % obj.__class__.__name__)
-            self.assertRaises(ValueError, to_openmath, {})
+            self.assertRaises(ValueError, DefaultConverter.to_openmath, {})
 
     def test_register_str(self):
         def str_to_om(str):
             return om.OMString('Hello' + str)
         def str_to_py(om):
             return om.string + 'world'
-        
-        register(str, str_to_om, om.OMString, str_to_py)
-        self.assertEqual(to_python(to_openmath(' ')), 'Hello world')
+
+        DefaultConverter.register(str, str_to_om, om.OMString, str_to_py)
+        self.assertEqual(DefaultConverter.to_python(DefaultConverter.to_openmath(' ')), 'Hello world')
 
     def test_register_sym(self):
-        register_to_python('hello1', 'hello', 'world')
-        self.assertEqual(to_python(om.OMSymbol(cd='hello1', name='hello')), 'world')
+        DefaultConverter.register_to_python('hello1', 'hello', 'world')
+        self.assertEqual(DefaultConverter.to_python(om.OMSymbol(cd='hello1', name='hello')), 'world')
         def echo(obj):
             return obj.name
-        register_to_python('echo1', 'echo', echo)
-        self.assertEqual(to_python(om.OMSymbol(cd='echo1', name='echo')), 'echo')
+        DefaultConverter.register_to_python('echo1', 'echo', echo)
+        self.assertEqual(DefaultConverter.to_python(om.OMSymbol(cd='echo1', name='echo')), 'echo')
 
     def test_register_skip(self):
         def skip(obj):
             raise CannotConvertError()
-        register_to_openmath(None, skip)
-        self.assertEqual(to_openmath('hello'), om.OMString('hello'))
+        DefaultConverter.register_to_openmath(None, skip)
+        self.assertEqual(DefaultConverter.to_openmath('hello'), om.OMString('hello'))
 
     def test_underscore(self):
         class test:
             def __openmath__(self):
                 return om.OMInteger(1)
-        self.assertEqual(to_python(to_openmath(test())), 1)
+        self.assertEqual(DefaultConverter.to_python(DefaultConverter.to_openmath(test())), 1)
 
     def test_rational(self):
         def to_om_rat(obj):
             return om.OMApplication(om.OMSymbol('rational', cd='nums1'),
-                                    map(to_openmath, [obj.numerator, obj.denominator]))
+                                    map(DefaultConverter.to_openmath, [obj.numerator, obj.denominator]))
         def to_py_rat(obj):
-            return Fraction(to_python(obj.arguments[0]), to_python(obj.arguments[1]))
-        register(Fraction, to_om_rat, 'nums1', 'rational', to_py_rat)
+            return Fraction(DefaultConverter.to_python(obj.arguments[0]), DefaultConverter.to_python(obj.arguments[1]))
+        DefaultConverter.register(Fraction, to_om_rat, 'nums1', 'rational', to_py_rat)
 
         a = Fraction(10, 12)
-        self.assertEqual(a, to_python(to_openmath(a)))
+        self.assertEqual(a, DefaultConverter.to_python(DefaultConverter.to_openmath(a)))
 


### PR DESCRIPTION
Previously, the convert module stored registered conversion functions inside global state. This made for akward code and also made it difficult to register multiple conversion functions for the same symbol.

This PR fixes the issue by introducing a new Converter class which stores all previously global state. For convenience, an instance of this class called ``DefaultConverter`` is provided as well.  Furthermore, this PR updates the tests and documentation accordingly.