### PR TITLE
Properly convert floating point numbers (fixes #31)

### DIFF
--- a/openmath/encoder.py
+++ b/openmath/encoder.py
@@ -54,7 +54,7 @@ def encode_xml(obj, E=None):
     elif isinstance(obj, om.OMInteger):
         children.append(str(obj.integer))
     elif isinstance(obj, om.OMFloat):
-        attr["dec"] = obj.double
+        attr["dec"] = str(obj.double).replace("+", "")
     elif isinstance(obj, om.OMString):
         if obj.string is not None:
             children.append(str(obj.string))


### PR DESCRIPTION
Previously floating point numbers in exponential notation with a positive exponent were converted to openmath incorrectly. As raised in issue #31 an extra "+" was added in the XML. This PR fixes the issue by removing the "+".