### PR TITLE
Convert range() objects using 'integer_interval' from cd 'interval1'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ By default, a ``Converter`` only implements conversions for basic Python types:
 - complex numbers,
 - strings,
 - bytes,
+- ranges,
 - lists (recursively),
 - sets (recursively).
 

--- a/openmath/convert.py
+++ b/openmath/convert.py
@@ -259,6 +259,7 @@ class BasicPythonConverter(Converter):
     - complex numbers (recursively),
     - strings,
     - bytes,
+    - ranges,
     - lists (recursively),
     - sets (recursively).
     """
@@ -278,6 +279,8 @@ class BasicPythonConverter(Converter):
         r('set1', 'set', lambda *args: set(args))
         r('list1', 'list', lambda *args: list(args))
         r('complex1', 'complex_cartesian', complex) # this does not work if the arguments are not numbers
+        r('interval1', 'integer_interval', lambda x,y: range(x, y + 1, 1))
+
         # literals
         s = self.register_to_python_class
         s(om.OMInteger, lambda o: o.integer)
@@ -311,6 +314,12 @@ class BasicPythonConverter(Converter):
             else:
                 return oms('emptyset', cd='set1')
         t(set, do_set)
+        def do_range(r):
+            if r.step != 1:
+                raise ValueError('Cannot convert %r to OpenMath: Range must have a step of 1. ' % obj)
+            return om.OMApplication(oms('integer_interval', 'interval1'), [om.OMInteger(r.start), om.OMInteger(r.stop - 1)])
+        t(range, do_range)
+
 
 
 # A default converter instance for convenience

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -15,6 +15,7 @@ class TestConvert(unittest.TestCase):
             "", "test",
             [], [1,2,3],
             set(), set([1,2,3]),
+            range(1, 12)
         ]
         for obj in testcases:
             conv = DefaultConverter.to_python(DefaultConverter.to_openmath(obj))


### PR DESCRIPTION
This issue adds translation for the range() class to the DefaultConverter. Note that a python range(start, stop) does not include the value of stop, whereas the 'integer_interval' symbol does. The converter thus has to add or subtract one.

Fixes #29.